### PR TITLE
Add Serverless and Upgrade Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Public Docker Images to support Chain.io
 
 Intended to be used by CI for services running on AWS Lambda
 
-Contains Node 6.10.3 and a current / stable version of [Yarn](https://yarnpkg.com/en/)
+- Node 6.10.3
+- Current / Stable version of Yarn
+- AWS CLI
+- [Serverless Framework](https://serverless.com/) for Deployment purposes
 
 `chainio/sphinx-docs`
 

--- a/lambda/nodejs6.10/Dockerfile
+++ b/lambda/nodejs6.10/Dockerfile
@@ -22,4 +22,6 @@ RUN sudo apt-get update
 RUN sudo apt-get install python-pip python-dev jq
 RUN sudo pip install awscli
 
+RUN yarn global add serverless@1.26
+
 USER circleci

--- a/lambda/nodejs6.10/Dockerfile
+++ b/lambda/nodejs6.10/Dockerfile
@@ -1,6 +1,6 @@
 FROM circleci/node:6.10.3
 
-ENV YARN_VERSION 1.3.2
+ENV YARN_VERSION 1.6.0
 
 USER root
 


### PR DESCRIPTION
- Upgrade Yarn to 1.6.0
- Add Serverless to image.  Most chainio repos use this for deployment