### PR TITLE
Upgraded Serverless to 1.29

### DIFF
--- a/lambda/nodejs6.10/Dockerfile
+++ b/lambda/nodejs6.10/Dockerfile
@@ -22,6 +22,6 @@ RUN sudo apt-get update
 RUN sudo apt-get install python-pip python-dev jq
 RUN sudo pip install awscli
 
-RUN yarn global add serverless@1.26
+RUN yarn global add serverless@1.29
 
 USER circleci


### PR DESCRIPTION
This is required for Lambda SQS trigger support

If you want to test it, you can see [Docker build](https://hub.docker.com/r/chainio/lambda-ci-nodejs6.10/builds/) with tag `:upgrade-serverless`.  I don't think its necessary though

The [Changelog](https://github.com/serverless/serverless/blob/master/CHANGELOG.md) is here and I Don't see anything that would impact us