### PR TITLE
Add script to assume AWS Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-## Chain.io Docker Images
+# Chain.io Docker Images
 
 Public Docker Images to support Chain.io
 
 [DockerHub](https://hub.docker.com/r/chainio)
 
-### Images
+## Images
 
-`chainio/lambda-ci-nodejs6.10`:
+### chainio/lambda-ci-nodejs6.10:
 
 Intended to be used by CI for services running on AWS Lambda
 
@@ -15,13 +15,28 @@ Intended to be used by CI for services running on AWS Lambda
 - AWS CLI
 - [Serverless Framework](https://serverless.com/) for Deployment purposes
 
-`chainio/sphinx-docs`
+#### Assuming AWS roels:
+
+This image contains a script for assuming AWS Roles
+
+It can be called like `source assume_aws_role`
+
+The following environment variables must be set for it to work
+
+- CHAINIO_ENV (environment to deploy to)
+- MASTER_AWS_KEY_ID (AWS_ACCESS_KEY_ID for master account)
+- MASTER_AWS_SECRET (AWS_SECRET_ACCESS_KEY for master account)
+- <environment>_role_arn (Role ARN to assume.  IE "dev_role_arn")
+
+It will automatically set AWS_SECRET_ACCESS_KEY, AWS_ACCESS_KEY_ID, and AWS_SESSION_TOKEN with the requested temporary credentials for the apprpriate environment
+
+### chainio/sphinx-docs
 
 Intended for Continuous Deployment of sphinx based websites to AWS
 
 Contains Python 2, AWS CLI and [Sphinx](http://www.sphinx-doc.org/en/stable/)
 
-### Making changes
+## Making changes
 
 To test locally use `docker build <Dockerfile path>`
 

--- a/lambda/nodejs6.10/Dockerfile
+++ b/lambda/nodejs6.10/Dockerfile
@@ -24,4 +24,7 @@ RUN sudo pip install awscli
 
 RUN yarn global add serverless@1.29
 
+ADD assume_aws_role.sh /usr/local/bin/assume_aws_role
+RUN chmod +x /usr/local/bin/assume_aws_role
+
 USER circleci

--- a/lambda/nodejs6.10/assume_aws_role.sh
+++ b/lambda/nodejs6.10/assume_aws_role.sh
@@ -1,0 +1,10 @@
+unset  AWS_SESSION_TOKEN
+
+role_env_name=${CHAINIO_ENV}_role_arn
+temp_role=$(AWS_ACCESS_KEY_ID=$MASTER_AWS_KEY_ID AWS_SECRET_ACCESS_KEY=$MASTER_AWS_SECRET aws sts assume-role \
+                    --role-arn "${!role_env_name}" \
+                    --role-session-name "circleci" )
+
+export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)

--- a/lambda/nodejs6.10/assume_aws_role.sh
+++ b/lambda/nodejs6.10/assume_aws_role.sh
@@ -1,6 +1,15 @@
-unset  AWS_SESSION_TOKEN
+[ -z "$CHAINIO_ENV" ] && echo "Must set CHAINIO_ENV to current environment" && exit 1;
+[ -z "$MASTER_AWS_KEY_ID" ] && echo "Must set MASTER_AWS_KEY_ID" && exit 1;
+[ -z "$MASTER_AWS_SECRET" ] && echo "Need to set MASTER_AWS_SECRET" && exit 1;
 
 role_env_name=${CHAINIO_ENV}_role_arn
+
+[ -z "${!role_env_name}" ] && echo "Missing environment variable $role_env_name to deploy to $CHAINIO_ENV" && exit 1;
+
+unset  AWS_SESSION_TOKEN
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+
 temp_role=$(AWS_ACCESS_KEY_ID=$MASTER_AWS_KEY_ID AWS_SECRET_ACCESS_KEY=$MASTER_AWS_SECRET aws sts assume-role \
                     --role-arn "${!role_env_name}" \
                     --role-session-name "circleci" )

--- a/lambda/nodejs6.10/assume_aws_role.sh
+++ b/lambda/nodejs6.10/assume_aws_role.sh
@@ -8,7 +8,3 @@ temp_role=$(AWS_ACCESS_KEY_ID=$MASTER_AWS_KEY_ID AWS_SECRET_ACCESS_KEY=$MASTER_A
 export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
 export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
 export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
-
-echo "SET KEYS ${temp_role}"
-echo "ACCESS_KEY_ID"
-echo $AWS_ACCESS_KEY_ID

--- a/lambda/nodejs6.10/assume_aws_role.sh
+++ b/lambda/nodejs6.10/assume_aws_role.sh
@@ -8,3 +8,7 @@ temp_role=$(AWS_ACCESS_KEY_ID=$MASTER_AWS_KEY_ID AWS_SECRET_ACCESS_KEY=$MASTER_A
 export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
 export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
 export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+
+echo "SET KEYS ${temp_role}"
+echo "ACCESS_KEY_ID"
+echo $AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Script will allow CircleCI to easily assume roles in AWS to deploy based on environment variables (set in Circle CI contexts)