### PR TITLE
Assume role sphinx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_store

--- a/sphinx-docs/Dockerfile
+++ b/sphinx-docs/Dockerfile
@@ -2,3 +2,6 @@ FROM python:2
 
 RUN pip install --no-cache-dir sphinx
 RUN pip install --no-cache-dir awscli
+
+ADD assume_aws_role.sh /usr/local/bin/assume_aws_role
+RUN chmod +x /usr/local/bin/assume_aws_role

--- a/sphinx-docs/assume_aws_role.sh
+++ b/sphinx-docs/assume_aws_role.sh
@@ -1,0 +1,19 @@
+[ -z "$CHAINIO_ENV" ] && echo "Must set CHAINIO_ENV to current environment" && exit 1;
+[ -z "$MASTER_AWS_KEY_ID" ] && echo "Must set MASTER_AWS_KEY_ID" && exit 1;
+[ -z "$MASTER_AWS_SECRET" ] && echo "Need to set MASTER_AWS_SECRET" && exit 1;
+
+role_env_name=${CHAINIO_ENV}_role_arn
+
+[ -z "${!role_env_name}" ] && echo "Missing environment variable $role_env_name to deploy to $CHAINIO_ENV" && exit 1;
+
+unset  AWS_SESSION_TOKEN
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+
+temp_role=$(AWS_ACCESS_KEY_ID=$MASTER_AWS_KEY_ID AWS_SECRET_ACCESS_KEY=$MASTER_AWS_SECRET aws sts assume-role \
+                    --role-arn "${!role_env_name}" \
+                    --role-session-name "circleci" )
+
+export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)


### PR DESCRIPTION
This adds a bash script to the docker image we use for sphinx, so that CircleCI can assume the appropriate AWS roles to deploy

chainio-docs should be able to deploy after:

- [ ] This is merged to master
- [ ] The [DockerHub build](https://hub.docker.com/r/chainio/sphinx-docs/builds/) is completed.  This may take 30+ minutes