### PR TITLE
symlink node and npm from nvm version directory

### DIFF
--- a/lambda/nodejs16.15/Dockerfile
+++ b/lambda/nodejs16.15/Dockerfile
@@ -1,8 +1,11 @@
-FROM cimg/node:16.15
+FROM cimg/node:16.15.1
 
 USER root
 
 ENV YARN_VERSION 1.22.5
+
+# symlink to fix missing node and npm links
+RUN sudo ln -s "/home/circleci/.nvm/versions/node/v16.15.1/bin/node" "/usr/local/bin/node" && sudo ln -s "/home/circleci/.nvm/versions/node/v16.15.1/bin/npm" "/usr/local/bin/npm"
 
 RUN mkdir ~/.gnupg
 RUN echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf


### PR DESCRIPTION
Related to cimg/node issue: https://github.com/CircleCI-Public/cimg-node/issues/248

From [Slack](https://chainio.slack.com/archives/C025Z9MMNBA/p1663175380881639): 

> ...when deploy[ing] the repo (it's a dockerized repo because of libxmljs2) with the `chainio/lambda-ci-nodejs16.15` image, docker quickly terminates with `node_1  | Yarn requires Node.js 4.0 or higher to be installed.` .
> The [build job in CircleCI](https://app.circleci.com/pipelines/github/mbsctech/amber-road-adapters/986/workflows/9b0f5dc1-5d34-4c87-be57-9c86e933c5e2/jobs/1339) has no issue, but deploying from local does not work.
> When running and executing both the `chainio/lambda-ci-nodejs16.15` image and the `cimg/node:16.15` image that it's based on, node does not appear to be in the `$PATH`. There is no such issue with the `cimg/node:14.16.1` image.

### Evidence of Testing

Building image locally

<img width="1411" alt="Screen Shot 2022-09-14 at 2 00 07 PM" src="https://user-images.githubusercontent.com/11944012/190228518-9f15e48c-1841-4d4b-8da8-2ab774b4a7f1.png">

Finding `node` and `npm`

<img width="855" alt="Screen Shot 2022-09-14 at 1 54 32 PM" src="https://user-images.githubusercontent.com/11944012/190228549-68640f85-2edd-40af-b46e-ace1bb88da15.png">
