### PR TITLE
CA-71 Updated serverless to 3.22 in docker images

### DIFF
--- a/lambda/nodejs12.18/Dockerfile
+++ b/lambda/nodejs12.18/Dockerfile
@@ -6,28 +6,14 @@ ENV YARN_VERSION 1.19.1
 
 RUN mkdir ~/.gnupg
 RUN echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
-RUN set -ex \
-  && for key in \
-  6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-  gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-  gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-  gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-  done \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
-  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && mkdir -p /opt \
-  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-  && ln -sf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-  && ln -sf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+RUN echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
+# RUN npm install -g yarn@1.19.1 # cimg/node:14.18.2 pre-installs yarn at 1.22.4
 
 RUN sudo apt-get update
 RUN sudo apt-get install python-pip python-dev jq
 RUN sudo pip install awscli
 
-RUN yarn global add serverless@1.59.1
+RUN yarn global add serverless@3.22
 
 ADD assume_aws_role.sh /usr/local/bin/assume_aws_role
 RUN chmod +x /usr/local/bin/assume_aws_role

--- a/lambda/nodejs14.16/Dockerfile
+++ b/lambda/nodejs14.16/Dockerfile
@@ -6,29 +6,14 @@ ENV YARN_VERSION 1.22.5
 
 RUN mkdir ~/.gnupg
 RUN echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
-RUN set -ex \
-  && for key in \
-  6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-  gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-  gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-  gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
-  done \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
-  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && mkdir -p /opt \
-  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-  && ln -sf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-  && ln -sf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+# RUN npm install -g yarn # cimg/node:14.16.1 pre-installs yarn at 1.22.10
 
 RUN sudo apt-get update
 RUN sudo apt-get install python3-pip python-dev jq
 RUN sudo pip install awscli
 RUN sudo pip install aws-sam-cli
 
-RUN yarn global add serverless@1.83.2
+RUN yarn global add serverless@3.22
 
 ADD assume_aws_role.sh /usr/local/bin/assume_aws_role
 RUN chmod +x /usr/local/bin/assume_aws_role


### PR DESCRIPTION
<!-- INCLUDE A DESCRIPTIVE PR TITLE TO DOCUMENT THE CHANGE BEING MADE -->

<!-- DIRECTLY BELOW, PASTE THE URL TO THE AIRTABLE OR AHA TASK THIS PR CORRESPONDS TO -->
### Related Task
[Task](https://chainio.aha.io/develop/features/CA-71)

### Change Summary
- Updated docker images for node 12.x and 14.x to use serverless framework 3.22

----

<!-- DOCUMENT PRE-MERGE AND TESTING REQUIREMENTS -->
### To Do
- [X] test in Red
- [X] deployed images to DockerHub
<!-- - [ ] merge github.com/mbsctech/.../pull/... -->
<!-- - [ ] upload manifest to Red -->
<!-- - [ ] upload manifest to Production -->
<!-- - [ ] publish to NPM -->

### Evidence of Testing
<!-- INSERT SCREENSHOT / PROOF OF CHANGE -->
