### PR TITLE
Update serverless version to one that supports node 20

### DIFF
--- a/lambda/nodejs20.9/Dockerfile
+++ b/lambda/nodejs20.9/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
 
 RUN sudo apt-get update
 
-RUN yarn global add serverless@3.33.0
+RUN yarn global add serverless@3.38.0
 
 RUN sudo apt-get install python3-pip
 RUN sudo pip install awscli aws-sam-cli


### PR DESCRIPTION
<!-- INCLUDE A DESCRIPTIVE PR TITLE TO DOCUMENT THE CHANGE BEING MADE -->
Update serverless version to one that supports node 20

<!-- DIRECTLY BELOW, PASTE THE URL TO THE AIRTABLE OR AHA TASK THIS PR CORRESPONDS TO -->
### Related Task
[Task](https://chainio.aha.io/features/DEV-41)

### Change Summary
- Update serverless version to one that supports node 20

----

<!-- DOCUMENT PRE-MERGE AND TESTING REQUIREMENTS -->
### To Do

### Evidence of Testing
<!-- INSERT SCREENSHOT / PROOF OF CHANGE -->
<img width="812" alt="Screen Shot 2023-12-01 at 3 33 11 PM" src="https://github.com/mbsctech/chainio-docker/assets/379057/b1e2d010-a8e9-49a3-a292-ad3e4afce0c9">
