### PR TITLE
Add builds for nodejs22 on arm64 and amd64 

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,15 +123,16 @@ Login as `chainioadmin`:
 
 You can find the credentials in lastpass if it is shared with you.
 
-First build the image via docker build:
+First build the image via docker build.  Because of the differences in platforms between different
+Mac processors, use the platform flags to ensure the platforms are consistent.
 
-eg: `docker build lambda/nodejs20.9 -t chainio/lambda-ci-nodejs20.9`
+`docker buildx build --platform linux/amd64 lambda/nodejs20.9 -t chainio/lambda-ci-nodejs20.9-amd64`
 
 Then push the image to docker hub:
 
 `docker push chainio/lambda-ci-nodejs20.9`
 
-For an arm version:
+For the arm version:
 `docker buildx build --platform linux/arm64 lambda/nodejs20.9 -t chainio/lambda-ci-nodejs20.9-arm64`
 
 Then push the image to docker hub:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Public Docker Images to support Chain.io
 
 ## Images
 
+### chainio/lambda-ci-nodejs22.11:
+
+Intended to be used by CI for services running on AWS Lambda
+
+- Node 22.11
+- Yarn 1.22.22
+- AWS CLI
+- [OSS Serverless Framework](https://github.com/oss-serverless/serverless) 3.43 for Deployment purposes
+
 ### chainio/lambda-ci-nodejs20.9:
 
 Intended to be used by CI for services running on AWS Lambda
@@ -13,7 +22,7 @@ Intended to be used by CI for services running on AWS Lambda
 - Node 20.9
 - Current / Stable version of Yarn
 - AWS CLI
-- [Serverless Framework](https://serverless.com/) 3.33 for Deployment purposes
+- [Serverless Framework](https://serverless.com/) 3.38 for Deployment purposes
 
 ### chainio/lambda-ci-nodejs18.16:
 
@@ -97,9 +106,9 @@ Contains Python 2, AWS CLI and [Sphinx](http://www.sphinx-doc.org/en/stable/)
 
 ## Making changes
 
-To test locally use `docker build <Dockerfile path>`
+To test locally, change to directory with Dockerfile and run `docker build . -t nodejs<version>`
 
-Example: `docker build lambda/nodejs6.10`
+Example: `cd lambda/nodejs22.10 && docker build . -t nodejs22.10`
 
 You must manually use docker login & push to push to dockerhub.
 

--- a/lambda/nodejs22.11/Dockerfile
+++ b/lambda/nodejs22.11/Dockerfile
@@ -1,0 +1,14 @@
+FROM cimg/node:22.11
+
+USER root
+
+RUN mkdir ~/.gnupg &&\
+    echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf &&\
+    yarn global add osls@3.43.0 &&\
+    sudo apt-get update &&\
+    sudo apt-get install python3-pip &&\
+    sudo pip install awscli aws-sam-cli
+
+COPY --chmod=755 assume_aws_role.sh /usr/local/bin/assume_aws_role
+
+USER circleci

--- a/lambda/nodejs22.11/assume_aws_role.sh
+++ b/lambda/nodejs22.11/assume_aws_role.sh
@@ -6,7 +6,7 @@ role_env_name=${CHAINIO_ENV}_role_arn
 
 [ -z "${!role_env_name}" ] && echo "Missing environment variable $role_env_name to deploy to $CHAINIO_ENV" && exit 1;
 
-unset  AWS_SESSION_TOKEN
+unset AWS_SESSION_TOKEN
 unset AWS_ACCESS_KEY_ID
 unset AWS_SECRET_ACCESS_KEY
 

--- a/lambda/nodejs22.11/assume_aws_role.sh
+++ b/lambda/nodejs22.11/assume_aws_role.sh
@@ -1,0 +1,19 @@
+[ -z "$CHAINIO_ENV" ] && echo "Must set CHAINIO_ENV to current environment" && exit 1;
+[ -z "$MASTER_AWS_KEY_ID" ] && echo "Must set MASTER_AWS_KEY_ID" && exit 1;
+[ -z "$MASTER_AWS_SECRET" ] && echo "Need to set MASTER_AWS_SECRET" && exit 1;
+
+role_env_name=${CHAINIO_ENV}_role_arn
+
+[ -z "${!role_env_name}" ] && echo "Missing environment variable $role_env_name to deploy to $CHAINIO_ENV" && exit 1;
+
+unset  AWS_SESSION_TOKEN
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+
+temp_role=$(AWS_ACCESS_KEY_ID=$MASTER_AWS_KEY_ID AWS_SECRET_ACCESS_KEY=$MASTER_AWS_SECRET aws sts assume-role \
+                    --role-arn "${!role_env_name}" \
+                    --role-session-name "circleci" )
+
+export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)


### PR DESCRIPTION
<!-- INCLUDE A DESCRIPTIVE PR TITLE TO DOCUMENT THE CHANGE BEING MADE -->

<!-- DIRECTLY BELOW, PASTE THE URL TO THE AIRTABLE OR AHA TASK THIS PR CORRESPONDS TO -->
### Related Task
[Task](#paste-task-url)

### Change Summary
- Added directory to build image with nodejs22.11 support based from CircleCI image
- Refactored all run commands into a single command to make all runs a single layer

----

<!-- DOCUMENT PRE-MERGE AND TESTING REQUIREMENTS -->
### To Do
- [x] test in Red
<!-- - [ ] merge github.com/mbsctech/.../pull/... -->
<!-- - [ ] upload manifest to Red -->
<!-- - [ ] upload manifest to Production -->
<!-- - [ ] publish to NPM -->

### Evidence of Testing
Cargowise eAdaptor Launcher Lambda built and deployed using the amd64 variant:
![Screenshot 2024-11-27 at 2 40 48 PM](https://github.com/user-attachments/assets/00b7c5e0-122a-4ac9-8e8f-d7c81c7ad664)

eAdapter Launcher Live Tail Logs showing it's working without issue - even with native libs (libxmljs):
![Screenshot 2024-11-27 at 2 42 23 PM](https://github.com/user-attachments/assets/6e9e6aa1-42ac-417b-aa77-9fe2ad544e59)

Standard Shipment JSON OC built and deployed in red with CircleCI arm64 variant:
![Screenshot 2024-11-27 at 2 09 15 PM](https://github.com/user-attachments/assets/54755525-e133-4616-9316-34aada6976cc)

Execution running through Cargowise IC to Standard Shipment OC:
![Screenshot 2024-11-27 at 2 10 00 PM](https://github.com/user-attachments/assets/52c78151-3302-4fbe-b5cf-988165662977)
