### PR TITLE
Node22 Amazon/Lambda based images

### DIFF
--- a/lambda/amazon-nodejs22/build/Dockerfile
+++ b/lambda/amazon-nodejs22/build/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -
 
 # jq and findutils (xargs) are used in the assume_aws_role.sh copied
 # into the build below
-RUN dnf install -y unzip python3-pip nodejs jq findutils gzip tar git \
+RUN dnf install -y unzip python3-pip nodejs jq findutils gzip tar git make gcc-c++ \
     && dnf clean all \
     && npm install -g yarn@1 \
     # Use osls fork instead of serverless due to serverless v4 issues

--- a/lambda/amazon-nodejs22/build/Dockerfile
+++ b/lambda/amazon-nodejs22/build/Dockerfile
@@ -1,0 +1,39 @@
+# Use Amazon Linux for our deployment/build images
+# New image tags are released every two years..2023, 2025, 2027, etc
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+# Add correct node version to dnf repo list
+# See https://github.com/nodesource/distributions for supported versions (use rpm)
+RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -
+
+# jq and findutils (xargs) are used in the assume_aws_role.sh copied
+# into the build below
+RUN dnf install -y unzip python3-pip nodejs jq findutils gzip tar git \
+    && dnf clean all \
+    && npm install -g yarn@1 \
+    # Use osls fork instead of serverless due to serverless v4 issues
+    && yarn global add osls@3.43.0
+
+# Install AWS CLI based on architecture selected
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+    else \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+    fi \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && rm -rf awscliv2.zip aws
+
+# Install AWS SAM CLI
+RUN pip3 install aws-sam-cli
+
+# Move our assume role script to folder in the shell's $PATH
+COPY --chmod=755 assume_aws_role.sh /usr/local/bin/assume_aws_role
+
+# Create a blank working directory for the app / build to default to running in
+WORKDIR /app
+
+# Verify node installation as default command - use the docker run cmd arg to specify
+# your actual command to run when using this image
+CMD ["node", "--version"]

--- a/lambda/amazon-nodejs22/build/assume_aws_role.sh
+++ b/lambda/amazon-nodejs22/build/assume_aws_role.sh
@@ -1,0 +1,19 @@
+[ -z "$CHAINIO_ENV" ] && echo "Must set CHAINIO_ENV to current environment" && exit 1;
+[ -z "$MASTER_AWS_KEY_ID" ] && echo "Must set MASTER_AWS_KEY_ID" && exit 1;
+[ -z "$MASTER_AWS_SECRET" ] && echo "Need to set MASTER_AWS_SECRET" && exit 1;
+
+role_env_name=${CHAINIO_ENV}_role_arn
+
+[ -z "${!role_env_name}" ] && echo "Missing environment variable $role_env_name to deploy to $CHAINIO_ENV" && exit 1;
+
+unset AWS_SESSION_TOKEN
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+
+temp_role=$(AWS_ACCESS_KEY_ID=$MASTER_AWS_KEY_ID AWS_SECRET_ACCESS_KEY=$MASTER_AWS_SECRET aws sts assume-role \
+                    --role-arn "${!role_env_name}" \
+                    --role-session-name "circleci" )
+
+export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
+export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
+export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)

--- a/lambda/amazon-nodejs22/test/Dockerfile
+++ b/lambda/amazon-nodejs22/test/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/lambda/nodejs:22
+
+# Tar is needed by the CircleCI build to pull build artifacts into the container
+RUN microdnf install -y tar gzip \
+  && npm install -g yarn@1
+
+WORKDIR /home
+
+ENTRYPOINT [ "uname", "-a"]

--- a/package.json
+++ b/package.json
@@ -15,6 +15,5 @@
   "engineStrict": true,
   "engines": {
     "node": ">=20"
-  },
-  "packageManager": "yarn@1.22.22"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "chainio-docker",
+  "version": "0.0.0",
+  "description": "A repository for building Chain.io docker images",
+  "repository": "git@github.com:mbsctech/chainio-docker",
+  "author": "Chain.io",
+  "license": "UNLICENSED",
+  "private": true,
+  "scripts": {
+    "build": "scripts/build-image.js",
+    "push": "scripts/push-image.js"
+  },
+  "dependencies": {
+  },
+  "engineStrict": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "packageManager": "yarn@1.22.22"
+}

--- a/scripts/build-image.js
+++ b/scripts/build-image.js
@@ -5,8 +5,17 @@ const fs = require('node:fs')
 const path = require('node:path')
 const { spawnSync } = require('node:child_process')
 
-let dryRun
+const validPlatforms = (platforms) => {
+  for (const platform of platforms) {
+    if (!['linux/amd64', 'linux/arm64'].includes(platform)) {
+      return false
+    }
+  }
 
+  return true
+}
+
+let dryRun
 const isDryRun = () => {
   return dryRun === true
 }
@@ -90,12 +99,13 @@ const getArgs = () => {
     return
   }
 
-  // TODO - validate platforms
   const rawPlatforms = values.platforms || 'linux/amd64, linux/arm64'
   const platforms = rawPlatforms.split(',').map(v => v.trim())
-
   if (!platforms.length) {
     error('You must specify at least one platform to build.')
+    return
+  } else if (!validPlatforms(platforms)){
+    error(`Invalid platform specified.  Must be one or more of ${VALID_PLATFORMS.join(', ')}`)
     return
   }
 

--- a/scripts/build-image.js
+++ b/scripts/build-image.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+const { parseArgs } = require('node:util')
+const fs = require('node:fs')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+let dryRun
+
+const isDryRun = () => {
+  return dryRun === true
+}
+
+const log = (message) => {
+  console.log(`${new Date().toISOString()} - ${message}`)
+}
+
+const error = (message, error) => {
+  if (message) {
+    console.error(`${new Date().toISOString()} - ${message}`)
+  }
+  if (error) {
+    console.error(error)
+  }
+}
+
+const isDirectory = (dir) => {
+  try {
+    return fs.statSync(dir).isDirectory()
+  } catch (er) {}
+  return false
+}
+
+const isFile = (dir) => {
+  try {
+    return fs.statSync(dir).isFile()
+  } catch (er) {}
+  return false
+}
+
+const getDirectoryNameFromPath = (dirPath) => {
+  return dirPath.split(path.sep).slice(-1)
+}
+
+const validateBuildDirectory = (buildDir) => {
+  if (!isDirectory(buildDir)) {
+    error(`The buildDir '${buildDir}' does not exist`)
+    return
+  }
+
+  // Older builds only use a single image...check for build/test dirs.  If present return the dockerfile
+  // paths for both.  If not, return only the build image.
+  const lambdaCiBuild = path.join(buildDir, 'build')
+  const lambdaCiTest = path.join(buildDir, 'test')
+  if (isDirectory(lambdaCiBuild) && isDirectory(lambdaCiTest)) {
+    const buildDockerFile = path.join(lambdaCiBuild, 'Dockerfile')
+    const testDockerFile = path.join(lambdaCiTest, 'Dockerfile')
+
+    if (isFile(buildDockerFile) && isFile(testDockerFile)) {
+      return { build: buildDockerFile, test: testDockerFile}
+    }
+
+    error(`Could not locate build/Dockerfile and/or test/Dockerfile in directory '${buildDir}'`)
+  } else {
+    const dockerFile = path.join(buildDir, 'Dockerfile')
+    if (isFile(dockerFile)) {
+      return { build: dockerFile }
+    }
+
+    error(`Could not locate legacy Dockerfile in directory '${buildDir}'`)
+  }
+}
+
+const getArgs = () => {
+  const commandLineOptions = {
+    buildDir: {
+      type: 'string'
+    },
+    tagPrefix: {
+      type: 'string'
+    },
+    platforms: {
+      type: 'string'
+    }
+  }
+  const { values } = parseArgs({ options: commandLineOptions, strict: false, allowPositionals: true })
+  dryRun = values.dryRun
+  if (!values.buildDir) {
+    error('You must specify the build directory to use.')
+    return
+  }
+
+  // TODO - validate platforms
+  const rawPlatforms = values.platforms || 'linux/amd64, linux/arm64'
+  const platforms = rawPlatforms.split(',').map(v => v.trim())
+
+  if (!platforms.length) {
+    error('You must specify at least one platform to build.')
+    return
+  }
+
+  const {build, test} = validateBuildDirectory(values.buildDir) || {}
+  if (!build) {
+    return
+  }
+
+  let tagPrefix = values.tagPrefix
+  if (!tagPrefix) {
+    // Generate a tagPrefix from the directory name
+    // Not using path.parse because dirs with periods in them
+    // appear to parse as files
+    const dirName = getDirectoryNameFromPath(values.buildDir)
+
+    if (test) {
+      tagPrefix = dirName
+    } else {
+      // use legacy naming if test directory isn't present
+      tagPrefix = `lambda-ci-${dirName}`
+    }
+  }
+
+  return {
+    dockerBuild: build,
+    dockerTest: test,
+    tagPrefix,
+    platforms,
+    dryRun: values.dryRun
+  }
+}
+
+const runCommand = (command) => {
+  if (isDryRun()) {
+    log(`DRY RUN command: ${command}`)
+    return true
+  } else {
+    log(`Executing command: ${command}`)
+  }
+
+  const result = spawnSync(command, { stdio: ['inherit', 'inherit', 'inherit'], shell: true})
+  if (result.error) {
+    error(result.error)
+    return false
+  }
+
+  return true
+}
+
+const buildTag = (platform, buildType, tag) => {
+  const tagComponents = [`chainio/${tag}`]
+
+  if (buildType !== 'build') {
+    tagComponents.push(buildType)
+  }
+
+  // The only valid platforms for us are linux/amd64 and linux/arm64 so just strip
+  // the linux and add to the tag as -amd64 and -arm64
+  const [, architecture] = platform.split('/')
+  if (architecture) {
+    tagComponents.push(architecture)
+  }
+
+  return tagComponents.join('-')
+}
+
+const getBuildContext = (dockerFile) => {
+  const parentDir = path.parse(dockerFile).dir
+  if (!parentDir) {
+    return '.'
+  }
+
+  return parentDir
+}
+
+const build = ({dockerFile, platform, buildType, tagPrefix}) => {
+  const actualTag = buildTag(platform, buildType, tagPrefix)
+  const buildContxt = getBuildContext(dockerFile)
+  log(`Building image using Dockerfile ${dockerFile} for platform ${platform} and tagging as ${actualTag} using build context of ${buildContxt}`)
+  if (runCommand(`docker buildx build --platform ${platform} --file ${dockerFile} -t ${actualTag} ${buildContxt}`)) {
+    return true
+  }
+  error('Failed to build image')
+  return false
+}
+
+const run = () => {
+  const { dockerBuild, dockerTest, tagPrefix, platforms } = (getArgs() || {})
+  if (!dockerBuild) {
+    return
+  }
+  const dockerBuilds = platforms.map((platform) => {
+    const args = []
+    args.push({ dockerFile: dockerBuild, buildType: 'build', platform, tagPrefix })
+    if (dockerTest) {
+      args.push({ dockerFile: dockerTest, buildType: 'test', platform, tagPrefix })
+    }
+    return args
+  }).flat()
+
+  log(`Executing ${dockerBuilds.length} builds.`)
+  for (const buildArgs of dockerBuilds) {
+    if (!build(buildArgs)) {
+      error('The build failed to complete.  Fix the build error before continuing.')
+      return
+    }
+  }
+}
+
+run()

--- a/scripts/push-image.js
+++ b/scripts/push-image.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+// If given a build directory, try and surmize the name of the builds to push - based on defaults
+// used in the build script.
+
+const { parseArgs } = require('node:util')
+const fs = require('node:fs')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+let dryRun
+const isDryRun = () => {
+  return dryRun === true
+}
+
+const log = (message) => {
+  console.log(`${new Date().toISOString()} - ${message}`)
+}
+
+const error = (message, error) => {
+  if (message) {
+    console.error(`${new Date().toISOString()} - ${message}`)
+  }
+  if (error) {
+    console.error(error)
+  }
+}
+
+const isDirectory = (dir) => {
+  try {
+    return fs.statSync(dir).isDirectory()
+  } catch (er) {}
+  return false
+}
+
+const getDirectoryNameFromPath = (dirPath) => {
+  return dirPath.split(path.sep).slice(-1)
+}
+
+const getArgs = () => {
+  const commandLineOptions = {
+    buildDir: {
+      type: 'string'
+    },
+    platforms: {
+      type: 'string'
+    }
+  }
+  const { values } = parseArgs({ options: commandLineOptions, strict: false, allowPositionals: true })
+  dryRun = values.dryRun
+  if (!values.buildDir) {
+    error('You must specify the build directory to push.')
+    return
+  } else if (!isDirectory(values.buildDir)) {
+    error(`The buildDir '${buildDir}' does not exist`)
+    return
+  }
+
+  const rawPlatforms = values.platforms || 'linux/amd64, linux/arm64'
+  const platforms = rawPlatforms.split(',').map(v => v.trim())
+  if (!platforms.length) {
+    error('You must specify at least one platform to push.')
+    return
+  }
+
+  return {
+    buildDir: values.buildDir,
+    platforms
+  }
+}
+
+const getBaseImageNames = (buildDir) => {
+  const names = []
+  const buildDirName = getDirectoryNameFromPath(buildDir)
+  if (isDirectory(path.join(buildDir, 'build'))) {
+    names.push(`chainio/${buildDirName}`)
+  }
+
+  if (isDirectory(path.join(buildDir, 'test'))) {
+    names.push(`chainio/${buildDirName}-test`)
+  }
+
+  if (names.length === 0) {
+    // If there's no build or test folder in the build dir, then fall back to the legacy naming style
+    names.push(`chainio/lambda-ci-${buildDirName}`)
+  }
+
+  return names
+}
+
+const getImageNamesToPush = (args) => {
+  const names = getBaseImageNames(args.buildDir)
+  return names.map((name) => {
+    return args.platforms.map((platform) => {
+      const [, architecture] = platform.split('/')
+      return `${name}-${architecture}`
+    })
+  }).flat()
+}
+
+const pushImage = (imageName) => {
+  log(`Pushing image named ${imageName} to Docker Hub`)
+  return runCommand(`docker push ${imageName}`)
+}
+
+const runCommand = (command) => {
+  if (isDryRun()) {
+    log(`DRY RUN command: ${command}`)
+    return true
+  } else {
+    log(`Executing command: ${command}`)
+  }
+
+  const result = spawnSync(command, { stdio: ['inherit', 'inherit', 'inherit'], shell: true})
+  if (result.error) {
+    error(result.error)
+    return false
+  }
+
+  return true
+}
+
+const run = () => {
+  const args = getArgs()
+  if (!args) {
+    return
+  }
+
+  const imageNames = getImageNamesToPush(args)
+  log(`Pushing ${imageNames.length} image${imageNames.length === 1 ? '' : 's'}`)
+  for (const imageName of imageNames) {
+    if (!pushImage(imageName)) {
+      error(`Failed to push image ${imageName}`)
+      return
+    }
+  }
+}
+
+run()

--- a/scripts/push-image.js
+++ b/scripts/push-image.js
@@ -8,6 +8,16 @@ const fs = require('node:fs')
 const path = require('node:path')
 const { spawnSync } = require('node:child_process')
 
+const validPlatforms = (platforms) => {
+  for (const platform of platforms) {
+    if (!['linux/amd64', 'linux/arm64'].includes(platform)) {
+      return false
+    }
+  }
+
+  return true
+}
+
 let dryRun
 const isDryRun = () => {
   return dryRun === true
@@ -59,7 +69,10 @@ const getArgs = () => {
   const rawPlatforms = values.platforms || 'linux/amd64, linux/arm64'
   const platforms = rawPlatforms.split(',').map(v => v.trim())
   if (!platforms.length) {
-    error('You must specify at least one platform to push.')
+    error('You must specify at least one platform to build.')
+    return
+  } else if (!validPlatforms(platforms)){
+    error(`Invalid platform specified.  Must be one or more of ${VALID_PLATFORMS.join(', ')}`)
     return
   }
 


### PR DESCRIPTION
<!-- INCLUDE A DESCRIPTIVE PR TITLE TO DOCUMENT THE CHANGE BEING MADE -->

### Change Summary
- Updates image build structure to create distinct build and test images.
  - build images are based on the amazonlinux:2023 image
  - test images are based on the actual lambda images
- Adds build script to make it easier to build images locally for all architectures and use cases
- Adds deploy script to deploy all images for a particular directory

----

<!-- DOCUMENT PRE-MERGE AND TESTING REQUIREMENTS -->
### To Do
- [x] test in Red
<!-- - [ ] merge github.com/mbsctech/.../pull/... -->
<!-- - [ ] upload manifest to Red -->
<!-- - [ ] upload manifest to Production -->
<!-- - [ ] publish to NPM -->

### Evidence of Testing
Images pushed to Docker Hub:
![Screenshot 2025-01-03 at 10 44 30 AM](https://github.com/user-attachments/assets/2009a0b3-8055-4494-8990-33ec34aee0dd)

CircleCI ARM64 build + deploy (uses both the build and test images in the CI/CD pipeline):
![Screenshot 2025-01-02 at 3 38 23 PM](https://github.com/user-attachments/assets/9b6f9886-0dfd-4996-8a22-fd8b0be5289d)

CircleCI AMD64 build + deploy (uses both the build and test images in the CI/CD pipeline):
![Screenshot 2025-01-03 at 10 02 54 AM](https://github.com/user-attachments/assets/d1cd6221-3cab-46f7-bb1f-c80931a5129c)

