### PR TITLE
Update osls version to avoid nodejs lambda runtime warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Includes:
 - Node 24.11
 - Yarn 1.22.22
 - AWS CLI 2.32.7
-- [OSS Serverless Framework](https://github.com/oss-serverless/serverless) 3.60 for Deployment purposes
+- [OSS Serverless Framework](https://github.com/oss-serverless/serverless) 3.61 for Deployment purposes
 
 ### chainio/amazon-nodejs22
 Introduces a new set of images built from Amazon's public image set:

--- a/lambda/amazon-nodejs24/build/Dockerfile
+++ b/lambda/amazon-nodejs24/build/Dockerfile
@@ -12,7 +12,7 @@ RUN dnf install -y unzip python3-pip nodejs jq findutils gzip tar git make gcc-c
     && dnf clean all \
     && npm install -g yarn@1 \
     # Use osls fork instead of serverless due to serverless v4 issues
-    && yarn global add osls@3.60.0
+    && yarn global add osls@3.61.0
 
 # Install AWS CLI based on architecture selected
 ARG TARGETARCH


### PR DESCRIPTION
### Change Summary
- Use latest osls version to remove missing lambda runtime warnings for nodejs 24.x

----

<!-- DOCUMENT PRE-MERGE AND TESTING REQUIREMENTS -->
### To Do
- [x] test in Red
<!-- - [ ] merge github.com/mbsctech/.../pull/... -->
<!-- - [ ] upload manifest to Red -->
<!-- - [ ] upload manifest to Production -->
<!-- - [ ] publish to NPM -->

### Evidence of Testing
Test run using latest image on nodejs 24 in new repo:
<img width="1776" height="589" alt="Screenshot 2025-12-16 at 2 40 39 PM" src="https://github.com/user-attachments/assets/4530e913-bc99-427a-9406-099cb4adc0a8" />
