### PR TITLE
1304: Upgrade osls to 3.63.2 for Lambda function URL permission fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Includes:
 - Node 24.11
 - Yarn 1.22.22
 - AWS CLI 2.32.7
-- [OSS Serverless Framework](https://github.com/oss-serverless/serverless) 3.61 for Deployment purposes
+- [OSS Serverless Framework](https://github.com/oss-serverless/serverless) 3.63.2 for Deployment purposes
 
 ### chainio/amazon-nodejs22
 Introduces a new set of images built from Amazon's public image set:
@@ -46,7 +46,7 @@ Includes:
 - Node 22.11
 - Yarn 1.22.22
 - AWS CLI
-- [OSS Serverless Framework](https://github.com/oss-serverless/serverless) 3.43 for Deployment purposes
+- [OSS Serverless Framework](https://github.com/oss-serverless/serverless) 3.63.2 for Deployment purposes
 
 ### chainio/lambda-ci-nodejs22.11:
 

--- a/lambda/amazon-nodejs22/build/Dockerfile
+++ b/lambda/amazon-nodejs22/build/Dockerfile
@@ -12,7 +12,8 @@ RUN dnf install -y unzip python3-pip nodejs jq findutils gzip tar git make gcc-c
     && dnf clean all \
     && npm install -g yarn@1 \
     # Use osls fork instead of serverless due to serverless v4 issues
-    && yarn global add osls@3.43.0
+    # Keep osls at v3.62.0 or newer to preserve the Lambda function URL permission fix (adds lambda:InvokeFunction alongside lambda:InvokeFunctionUrl)
+    && yarn global add osls@3.63.2
 
 # Install AWS CLI based on architecture selected
 ARG TARGETARCH

--- a/lambda/amazon-nodejs24/build/Dockerfile
+++ b/lambda/amazon-nodejs24/build/Dockerfile
@@ -12,7 +12,8 @@ RUN dnf install -y unzip python3-pip nodejs jq findutils gzip tar git make gcc-c
     && dnf clean all \
     && npm install -g yarn@1 \
     # Use osls fork instead of serverless due to serverless v4 issues
-    && yarn global add osls@3.61.0
+    # Keep osls at v3.62.0 or newer to preserve the Lambda function URL permission fix (adds lambda:InvokeFunction alongside lambda:InvokeFunctionUrl)
+    && yarn global add osls@3.63.2
 
 # Install AWS CLI based on architecture selected
 ARG TARGETARCH


### PR DESCRIPTION
## Summary

[[1304] AWS Lambda IAM Change](https://www.notion.so/29a47da21aff80aca720ca76644f1951)

- Upgrades `osls` in `lambda/amazon-nodejs22/build/Dockerfile` (3.43.0 → 3.63.2) and `lambda/amazon-nodejs24/build/Dockerfile` (3.61.0 → 3.63.2) so deployed Lambda function URLs get both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` permissions (required by AWS as of 2026-11-01; fix landed upstream in osls 3.62.0).
- Adds an inline comment in each Dockerfile noting the v3.62.0 minimum to guard against future regressions.
- Updates README osls version references to match.

Validated against the `try-now-red` CloudFormation stack: a second `AWS::Lambda::Permission` resource (`TryNowLambdaPermissionFn`, granting `lambda:InvokeFunction`) now appears alongside the existing `TryNowLambdaPermissionFnUrl` after redeploying with the upgraded image.

## Test Evidence

Built container locally w/ updated osls version and ran try-now deployment locally in red:
<img width="1286" height="487" alt="Screenshot 2026-04-22 at 11 53 44 AM" src="https://github.com/user-attachments/assets/d1a186ab-312a-40a0-baa7-3dd12950b121" />


Before missing function permission:
<img width="1397" height="323" alt="Screenshot 2026-04-22 at 11 25 00 AM" src="https://github.com/user-attachments/assets/117a1b43-1f20-42bc-b1e1-e3f363a94eb2" />

After with permisssion:
<img width="1408" height="475" alt="Screenshot 2026-04-22 at 11 27 07 AM" src="https://github.com/user-attachments/assets/2840da83-448b-4e30-9fc5-97ba5f6230df" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)